### PR TITLE
Tree support (as simple as possible).

### DIFF
--- a/api/src/main/java/jakarta/config/Config.java
+++ b/api/src/main/java/jakarta/config/Config.java
@@ -19,9 +19,11 @@
 package jakarta.config;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import jakarta.config.spi.ConfigSource;
 import jakarta.config.spi.Converter;
+import jakarta.config.spi.StringConverter;
 
 /**
  * Access to configuration values.
@@ -31,7 +33,8 @@ public interface Config {
      * Return all the currently registered {@link jakarta.config.spi.ConfigSource sources} for this configuration.
      * <p>
      * The returned sources will be sorted by priority and name, which can be iterated in a thread-safe
-     * manner. The {@link java.lang.Iterable Iterable} contains a fixed number of {@link jakarta.config.spi.ConfigSource configuration
+     * manner. The {@link java.lang.Iterable Iterable} contains a fixed number of {@link jakarta.config.spi.ConfigSource
+     * configuration
      * sources}, determined at application start time, and the config sources themselves may be static or dynamic.
      *
      * @return the configuration sources
@@ -39,7 +42,8 @@ public interface Config {
     Iterable<ConfigSource> getConfigSources();
 
     /**
-     * Return the {@link jakarta.config.spi.Converter} used by this instance to produce instances of the specified type from string values.
+     * Return the {@link jakarta.config.spi.Converter} used by this instance to produce instances of the specified type from
+     * string values.
      *
      * @param <T>
      *            the conversion type
@@ -49,6 +53,20 @@ public interface Config {
      *         type
      */
     <T> Optional<Converter<T>> getConverter(Class<T> forType);
+
+    /**
+     * Return the {@link jakarta.config.spi.StringConverter} used by this instance to produce instances of the specified type from
+     * string values.
+     * This is a helper method to provide simple conversions (such as from a default value of an annotation).
+     *
+     * @param <T>
+     *            the conversion type
+     * @param forType
+     *            the type to be produced by the converter
+     * @return an {@link java.util.Optional} containing the converter, or empty if no converter is available for the specified
+     *         type
+     */
+    <T> Optional<StringConverter<T>> getStringConverter(Class<T> forType);
 
     /**
      * Returns an instance of the specific class, to allow access to the provider specific API.
@@ -67,4 +85,76 @@ public interface Config {
      *             If the current provider does not support unwrapping to the given type
      */
     <T> T unwrap(Class<T> type);
+
+    /**
+     * Fully qualified key of this config node (such as {@code server.port}).
+     * Returns an empty String for root config.
+     *
+     * @return key of this config
+     */
+    String key();
+
+    /**
+     * Name of this node - the last element of a fully qualified key.
+     * <p>
+     * For example for key {@code server.port} this method would return {@code port}.
+     *
+     * @return name of this node
+     */
+    String name();
+
+    /**
+     * Single sub-node for the specified sub-key.
+     * For example if requested for key {@code server}, this method would return a config
+     * representing the {@code server} node, which would have for example a child {@code port}.
+     * The sub-key can return more than one level of nesting (e.g. using {@code server.tls} would
+     * return a node that contains the TLS configuration under {@code server} node).
+     *
+     * @param key sub-key to retrieve nested node.
+     * @return sub node, never null
+     */
+    Config get(String key);
+
+    /**
+     * Typed value created using a converter function.
+     * The converter is called only if this config node exists.
+     *
+     * @param converter to create an instance from config node
+     * @param <T> type of the object
+     * @return converted value of this node, or an empty optional if this node does not exist
+     * @throws java.lang.IllegalArgumentException if this config node cannot be converted to the desired type
+     */
+    <T> Optional<T> as(Function<Config, T> converter);
+
+    /**
+     * Typed value created using a discovered/built-in converter.
+     *
+     * @param type class to convert to
+     * @param <T> type of the object
+     * @return converted value of this node, or an empty optional if this node does not exist
+     * @throws java.lang.IllegalArgumentException if this config node cannot be converted to the desired type
+     */
+    <T> Optional<T> as(Class<T> type);
+
+    /**
+     * Direct value of this node used for string converters.
+     *
+     * @return value of this node
+     */
+    Optional<String> asString();
+
+    /**
+     * Config value associated with this tree node (if any).
+     * If this node represents a value obtained from a config source, this method must return a non-empty value.
+     *
+     * @return config value of this node, or empty if this node does not represent a direct value
+     */
+    Optional<ConfigValue> configValue();
+
+    /*
+     * Shortcut helper methods
+     */
+    default Optional<Integer> asInt() {
+        return as(Integer.class);
+    }
 }

--- a/api/src/main/java/jakarta/config/ConfigValue.java
+++ b/api/src/main/java/jakarta/config/ConfigValue.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+/**
+ * The ConfigValue holds additional information after the lookup of a configuration property and is itself immutable.
+ * <p>
+ * Holds information about the configuration property name, configuration value, the
+ * {@link jakarta.config.spi.ConfigSource} name from where the configuration property was loaded and
+ * the ordinal of the {@link jakarta.config.spi.ConfigSource}.
+ * <p>
+ * This is used together with {@link Config} to expose the configuration property lookup metadata.
+ *
+ * @since 2.0
+ * @author <a href="mailto:radcortez@yahoo.com">Roberto Cortez</a>
+ */
+public interface ConfigValue {
+    /**
+     * The key of the property.
+     *
+     * @return the name of the property.
+     */
+    String getKey();
+
+    /**
+     * The value of the property lookup with transformations (expanded, etc).
+     *
+     * @return the value of the property lookup or {@code null} if the property could not be found
+     */
+    String getValue();
+
+    /**
+     * The value of the property lookup without any transformation (expanded , etc).
+     *
+     * @return the raw value of the property lookup or {@code null} if the property could not be found.
+     */
+    String getRawValue();
+
+    /**
+     * The {@link jakarta.config.spi.ConfigSource} name that loaded the property lookup.
+     *
+     * @return the ConfigSource name that loaded the property lookup or {@code null} if the property could not be found
+     */
+    String getSourceName();
+
+    /**
+     * The {@link jakarta.config.spi.ConfigSource} ordinal that loaded the property lookup.
+     *
+     * @return the ConfigSource ordinal that loaded the property lookup or {@code 0} if the property could not be found
+     */
+    int getSourcePriority();
+}

--- a/api/src/main/java/jakarta/config/ReservedKeys.java
+++ b/api/src/main/java/jakarta/config/ReservedKeys.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+/**
+ * Reserved keys that have meaning for the configuration itself.
+ */
+public final class ReservedKeys {
+    private static final String CONFIG_PREFIX = "jakarta.config.";
+    /**
+     * The value of the property specifies a single active profile.
+     */
+    public static final String PROFILE = CONFIG_PREFIX + "profile";
+    /**
+     * The value of the property determines whether the property expression is enabled or disabled. The value
+     * <code>false</code> means the property expression is disabled, while <code>true</code> means enabled.
+     *
+     * By default, the value is set to <code>true</code>.
+     */
+    public static final String VALUE_EXPRESSIONS_ENABLED = CONFIG_PREFIX + "value.expressions.enabled";
+    /**
+     * The value of the property determines whether key expressions are enabled or disabled.
+     * Not used.
+     */
+    public static final String KEY_EXPRESSIONS_ENABLED = CONFIG_PREFIX + "key.expressions.enabled";
+    /**
+     * Priority of the config source.
+     * This property has no meaning when requested from config, only used for ordering of sources before
+     * config is created.
+     */
+    public static final String SOURCE_PRIORITY = CONFIG_PREFIX + "source.priority";
+    /**
+     * If we significantly change the way source is loaded, we may have a possibility to
+     * load it in the old approach.
+     */
+    public static final String SOURCE_VERSION = CONFIG_PREFIX + "source.version";
+
+    private ReservedKeys() {
+    }
+}

--- a/api/src/main/java/jakarta/config/spi/ConfigSource.java
+++ b/api/src/main/java/jakarta/config/spi/ConfigSource.java
@@ -18,10 +18,20 @@
  */
 package jakarta.config.spi;
 
+import java.util.Set;
+
+import jakarta.annotation.Priority;
+import jakarta.config.ReservedKeys;
+
 /**
  * A <em>configuration source</em> which provides configuration values from a specific place.
  */
 public interface ConfigSource {
+    /**
+     * Default priority of a config source.
+     */
+    int DEFAULT_PRIORITY = 1000;
+
     /**
      * The name of the configuration source. The name might be used for logging or for analysis of configured values,
      * and also may be used in ordering decisions.
@@ -31,4 +41,52 @@ public interface ConfigSource {
      * @return the name of the configuration source
      */
     String getName();
+
+    /**
+     * Return priority of this config source.
+     * Can be defined using a {@link jakarta.annotation.Priority}, may be overridden using
+     * key {@link jakarta.config.ReservedKeys#SOURCE_PRIORITY}, or by implementing this method.
+     *
+     * @return priority of this config source
+     */
+    default int getPriority() {
+        // use priority defined in config source data
+        String priority = getValue(ReservedKeys.SOURCE_PRIORITY);
+        if (priority != null) {
+            try {
+                return Integer.parseInt(priority);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        // use priority from annotation
+        Priority annotation = getClass().getAnnotation(Priority.class);
+        if (annotation != null) {
+            return annotation.value();
+        }
+
+        // use default priority
+        return DEFAULT_PRIORITY;
+    }
+
+    /**
+     * Return the value for the specified key in this configuration source.
+     *
+     * @param key
+     *            the property name
+     * @return the property value, or {@code null} if the property is not present
+     */
+    String getValue(String key);
+
+    /**
+     * Gets all property names known to this configuration source, potentially without evaluating the values. The
+     * returned property names may be a subset of the names of the total set of retrievable properties in this config
+     * source.
+     * <p>
+     * The returned set is not required to allow concurrent or multi-threaded iteration; however, if the same set is
+     * returned by multiple calls to this method, then the implementation must support concurrent and multi-threaded
+     * iteration of that set.
+     *
+     * @return a set of property names that are known to this configuration source
+     */
+    Set<String> getKeys();
 }

--- a/api/src/main/java/jakarta/config/spi/Converter.java
+++ b/api/src/main/java/jakarta/config/spi/Converter.java
@@ -18,8 +18,10 @@
  */
 package jakarta.config.spi;
 
+import jakarta.config.Config;
+
 /**
- * A mechanism for converting configured values from {@link String} to any Java type.
+ * A mechanism for converting configured config nodes to any Java type.
  *
  * <h2 id="global_converters">Global converters</h2>
  *
@@ -128,16 +130,16 @@ package jakarta.config.spi;
  */
 public interface Converter<T> {
     /**
-     * Convert the given string value to a specified type. Callers <em>must not</em> pass in {@code null} for
+     * Convert the given config node to a specified type. Callers <em>must not</em> pass in {@code null} for
      * {@code value}; doing so may result in a {@code NullPointerException} being thrown.
      *
-     * @param value
-     *            the string representation of a property value (must not be {@code null})
-     * @return the converted value, or {@code null} if the value is empty
+     * @param node
+     *            the config node to convert (must not be {@code null})
+     * @return the converted value, may be {@code null} to represent a missing value
      * @throws IllegalArgumentException
      *             if the value cannot be converted to the specified type
      * @throws NullPointerException
      *             if the given value was {@code null}
      */
-    T convert(String value) throws IllegalArgumentException, NullPointerException;
+    T convert(Config node) throws IllegalArgumentException, NullPointerException;
 }

--- a/api/src/main/java/jakarta/config/spi/StringConverter.java
+++ b/api/src/main/java/jakarta/config/spi/StringConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config.spi;
+
+import jakarta.config.Config;
+
+/**
+ * A mechanism for converting configured values from {@link String} to any Java type.
+ *
+ * This is a helper interface to support direct {@link String} conversion, for a generic
+ * conversion from nodes, please see {@link jakarta.config.spi.Converter}.
+ *
+ * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
+ * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
+ * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
+ * @author <a href="mailto:john.d.ament@gmail.com">John D. Ament</a>
+ */
+public interface StringConverter<T> extends Converter<T> {
+    /**
+     * Convert the given string value to a specified type. Callers <em>must not</em> pass in {@code null} for
+     * {@code value}; doing so may result in a {@code NullPointerException} being thrown.
+     *
+     * @param value
+     *            the string representation of a property value (must not be {@code null})
+     * @return the converted value, or {@code null} if the value is empty
+     * @throws IllegalArgumentException
+     *             if the value cannot be converted to the specified type
+     * @throws NullPointerException
+     *             if the given value was {@code null}
+     */
+    T convert(String value) throws IllegalArgumentException, NullPointerException;
+
+    @Override
+    default T convert(Config node) throws IllegalArgumentException, NullPointerException {
+        return node.asString()
+            .map(this::convert)
+            .orElse(null);
+    }
+}

--- a/tck/src/main/java/jakarta/config/tck/programmatic/ConfigResolverTest.java
+++ b/tck/src/main/java/jakarta/config/tck/programmatic/ConfigResolverTest.java
@@ -1,0 +1,113 @@
+package jakarta.config.tck.programmatic;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.config.Config;
+import jakarta.config.ConfigValue;
+import jakarta.config.ReservedKeys;
+import jakarta.config.spi.ConfigProviderResolver;
+import jakarta.config.spi.ConfigSource;
+import jakarta.config.spi.StringConverter;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test config resolver and its methods.
+ */
+public class ConfigResolverTest {
+    private static ConfigProviderResolver configProviderResolver;
+
+    @BeforeClass
+    static void init() {
+        configProviderResolver = ConfigProviderResolver.instance();
+    }
+
+    @Test
+    void testBuilder() {
+        Config config = configProviderResolver.getBuilder()
+            .withSources(new TestConfigSource())
+            .withConverters(new TestConverter())
+            .withConverter(TestPojo.class, 100, (StringConverter<TestPojo>) TestPojo::new)
+            .build();
+
+        Config serverNode = config.get("server");
+        assertThat(serverNode.asString(), is(Optional.of("value")));
+
+        Config hostNode = serverNode.get("host");
+        assertThat(hostNode.asString(), is(Optional.of("localhost")));
+        hostNode = config.get("server.host");
+        assertThat(hostNode.asString(), is(Optional.of("localhost")));
+        assertThat(hostNode.name(), is("host"));
+        assertThat(hostNode.key(), is("server.host"));
+
+        Config portNode = serverNode.get("port");
+        assertThat(portNode.asString(), is(Optional.of("7001")));
+        assertThat(portNode.asInt(), is(Optional.of(7001)));
+
+        Optional<ConfigValue> configValueOpt = serverNode.get("name").configValue();
+        assertThat(configValueOpt, not(Optional.empty()));
+
+        ConfigValue configValue = configValueOpt.get();
+
+        assertThat(configValue.getKey(), is("server.name"));
+        assertThat(configValue.getRawValue(), is("${name}"));
+        assertThat(configValue.getValue(), is("TckTest"));
+        assertThat(configValue.getSourceName(), is("TCK"));
+        assertThat(configValue.getSourcePriority(), is(542));
+    }
+
+    private static class TestConfigSource implements ConfigSource {
+        private final Map<String, String> values = Map.of(ReservedKeys.SOURCE_PRIORITY, "542",
+                                                          "name", "TckTest",
+                                                          "server", "value",
+                                                          "server.host", "localhost",
+                                                          "server.port", "7001",
+                                                          "server.name", "${name}");
+
+        @Override
+        public String getName() {
+            return "TCK";
+        }
+
+        @Override
+        public String getValue(String key) {
+            return values.get(key);
+        }
+
+        @Override
+        public Set<String> getKeys() {
+            return values.keySet();
+        }
+    }
+
+    private static class TestConverter implements StringConverter<TestPojoConverted> {
+        @Override
+        public TestPojoConverted convert(String value) throws IllegalArgumentException, NullPointerException {
+            return new TestPojoConverted(value);
+        }
+    }
+
+    private static class TestPojoConverted {
+        private final String value;
+
+        private TestPojoConverted(String value) {
+            this.value = value;
+        }
+    }
+
+    private static class TestPojo {
+        private final String value;
+
+        private TestPojo(String value) {
+            this.value = value;
+        }
+    }
+
+
+}


### PR DESCRIPTION
- using priority instead of ordinal
- minimal config source methods to implement tree structure
- converter supporting tree structure
- basic config API (without list children method)
- ReservedKeys.java added to centralize all reserved keys
- module-info.java update for annotations
- small pom changes

I have verified this API with an implementation, one TCK test (running and passing).

To use the TCK (maven):
add `tck-suite.xml` with the following content:
```xml
<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
<suite name="Config-TCK" verbose="10" configfailurepolicy="continue">
    <test name="programmatic-api">
        <packages>
            <package name="jakarta.config.tck.programmatic"/>
        </packages>
    </test>
</suite>
```

And add the following section to build:
```xml
<plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-failsafe-plugin</artifactId>
                <executions>
                    <execution>
                        <goals>
                            <goal>integration-test</goal>
                            <goal>verify</goal>
                        </goals>
                    </execution>
                </executions>
                <configuration>
                    <suiteXmlFiles>
                        <suiteXmlFile>src/test/tck-suite.xml</suiteXmlFile>
                    </suiteXmlFiles>
                </configuration>
            </plugin>
```